### PR TITLE
中间输出结果，避免爬取失败导致结果丢失；增强一些易用性和说明。

### DIFF
--- a/crawl/zhihui_scrapy_single_QA.py
+++ b/crawl/zhihui_scrapy_single_QA.py
@@ -19,18 +19,31 @@ headers = {
 
 start_url = 'https://www.zhihu.com/api/v4/questions/268384579/answers?include=data%5B%2A%5D.is_normal%2Cadmin_closed_comment%2Creward_info%2Cis_collapsed%2Cannotation_action%2Cannotation_detail%2Ccollapse_reason%2Cis_sticky%2Ccollapsed_by%2Csuggest_edit%2Ccomment_count%2Ccan_comment%2Ccontent%2Ceditable_content%2Cvoteup_count%2Creshipment_settings%2Ccomment_permission%2Ccreated_time%2Cupdated_time%2Creview_info%2Crelevant_info%2Cquestion%2Cexcerpt%2Crelationship.is_authorized%2Cis_author%2Cvoting%2Cis_thanked%2Cis_nothelp%3Bdata%5B%2A%5D.mark_infos%5B%2A%5D.url%3Bdata%5B%2A%5D.author.follower_count%2Cbadge%5B%2A%5D.topics&limit=5&offset=0&sort_by=default'
 
+print("running.")
+
 next_url = [start_url]
-answers = []
+count = 0
+
 for url in next_url:
     html = requests.get(url, headers=headers)
     html.encoding = html.apparent_encoding
     soup = BeautifulSoup(html.text, "lxml")
     content = str(soup.p).split("<p>")[1].split("</p>")[0]
     c = json.loads(content)
-    answers += [extract_answer(item["content"]) for item in c["data"] if extract_answer(item["content"]) != ""]
+
+    if "data" not in c:
+        print("获取数据失败，本 ip 可能已被限制。")
+        print(c)
+        break
+
+    answers = [extract_answer(item["content"]) for item in c["data"] if extract_answer(item["content"]) != ""]
+
+    for answer in answers:
+        count = count + 1
+        print("answer", count, ":", answer)
+
     next_url.append(c["paging"]["next"])
     if c["paging"]["is_end"]:
         break
-for item in answers:
-    print(item)
-print(len(answers))
+
+print("total answers:",count)


### PR DESCRIPTION
之前有次爬到一半被限制了（需要输入验证码），导致爬了几十分钟的数据没了，很难受。

所以改成中间输出，略微牺牲效率，换来好的稳定性。

增加了一些说明输出，比如答案编号。